### PR TITLE
Account for the latest SN API changes.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.gem
 *.rbc
 .bundle

--- a/lib/classes/configuration.rb
+++ b/lib/classes/configuration.rb
@@ -9,16 +9,15 @@ module ServiceNow
         end
 
         def self.get_resource(query_hash = {}, displayvalue = false, table)
-            # to be filled in
-            RestClient::Resource.new(URI.escape($root_url + "/#{table}.do?JSON&sysparm_action=getRecords&sysparm_query=#{hash_to_query(query_hash)}&displayvalue=#{displayvalue}"), $username, $password)
+            RestClient::Resource.new(URI.escape($root_url + "/api/now/v1/table/#{table}?sysparm_exclude_reference_link=true&sysparm_action=getRecords&sysparm_query=#{hash_to_query(query_hash)}&displayvalue=#{displayvalue}"), {user: $username, password: $password, headers: {accept: 'application/json'}})
         end
 
         def self.post_resource(table)
-            RestClient::Resource.new(URI.escape($root_url + "/#{table}.do?JSON&sysparm_action=insert"), $username, $password)
+            RestClient::Resource.new(URI.escape($root_url + "/api/now/v1/table/#{table}?sysparm_exclude_reference_link=true"), {user: $username, password: $password, headers: {accept: 'application/json', content_type: 'application/json'}})
         end
 
-        def self.update_resource(incident_number, table)
-           RestClient::Resource.new(URI.escape($root_url + "/#{table}.do?JSON&sysparm_query=number=#{incident_number}&sysparm_action=update"), $username, $password) 
+        def self.update_resource(incident_sys_id, table)
+           RestClient::Resource.new(URI.escape($root_url + "/api/now/v1/table/#{table}/#{incident_sys_id}?sysparm_exclude_reference_link=true"), {user: $username, password: $password, headers: {accept: 'application/json', content_type: 'application/json'}})
         end
 
         private

--- a/lib/classes/incident.rb
+++ b/lib/classes/incident.rb
@@ -1,105 +1,106 @@
 module ServiceNow
-    class Incident
+  class Incident
 
-        def inspect
-            @attributes.each do |k, v|
-                puts "#{k} => #{v}"
-            end
-        end
-
-        def initialize(attributes = {}, saved_on_sn = false, internal_call = false)
-            Incident.check_configuration
-            symbolized_attributes = Hash[attributes.map{|k, v| [k.to_sym, v]}]
-            if !symbolized_attributes[:number].nil? && !internal_call # allow setting INC number if it's called internally
-                raise "SN::ERROR: You are not allowed to set INC Number manually, the server will take care of that"
-            end
-            @attributes = symbolized_attributes
-            @saved_on_sn = saved_on_sn
-        end
- 
-        def attributes
-            @attributes
-        end
-
-        def client # must be used only when displayvable is false
-            return User.find_by_sys_id(self.caller_id)
-        end
-
-        def method_missing(method, args = nil)
-            method_name = method.to_s
-            if match = method_name.match(/(.*)=/) # writer method
-                attribute = match[1]
-                if attribute == "number" && @saved_on_sn
-                    raise "SN::ERROR: You are not allowed to set INC Number manually, the server will take care of that"
-                end
-                @attributes[attribute.to_sym] = args
-            else # reader method
-                @attributes[method_name.to_sym]
-            end
-        end
-
-        def save!
-            # if this is a new incident (still in memory and not on SN), and the user set the Incident number
-            # we raise an exception
-            if !@attributes[:number].nil? && !@saved_on_sn
-                raise "SN::ERROR: You are not allowed to set INC Number manually, the server will take care of that"
-            end
-            # we only create new incidents if it's not saved already
-            if !@saved_on_sn
-                response = Configuration.post_resource(table = "incident").post(self.attributes.to_json)
-            else
-                response = Configuration.update_resource(self.number, table = "incident").post(self.attributes.to_json)
-            end
-            hash = JSON.parse(response, { :symbolize_names => true })
-            # this is the object
-            # and there is always only one
-            # since we're creating or updating
-            inc_object = hash[:records][0]
-            inc_object.each do |key, value|
-                key_name = key.to_s
-                eval("self.#{key_name} = value")
-            end
-            @saved_on_sn = true
-            self
-        end
-
-        def self.find(inc_number)
-            Incident.check_configuration
-            inc_string = inc_number.to_s.match(/[123456789]+\d*$/).to_s
-            if inc_string.length > 7
-                raise "SN::Error: invalid Incident number"
-            end
-            query_hash = {}
-            query_hash[:number] = "INC" + "0"*(7-inc_string.length) + inc_string
-            response = Configuration.get_resource(query_hash, table = "incident").get();
-            # returned hash
-            hash = JSON.parse(response, { :symbolize_names => true })
-            # return the Incident object
-            inc_obj = Incident.new(attributes = hash[:records][0], saved_on_sn = true, internal_call = true)
-            if inc_obj.attributes.nil?
-                "SN::Alert: No incident with incident number #{query_hash[:number]} found"
-            else
-                inc_obj
-            end
-        end
-
-        def self.where(query_hash = {})
-            Incident.check_configuration
-            response = Configuration.get_resource(query_hash, table = "incident").get();
-            hash = JSON.parse(response, { :symbolize_names => true })
-            array_of_records = hash[:records]
-            array_of_inc = []
-            array_of_records.each do |record|
-                array_of_inc << Incident.new(attributes = record, saved_on_sn = true, internal_call = true)
-            end
-            array_of_inc
-        end
-
-        private
-            def self.check_configuration
-                if $root_url.nil? || $username.nil? || $password.nil?
-                    raise "SN::Error: You have not configured yet, please run ServiceNow::Configuration.configure() first"
-                end
-            end
+    def inspect
+      @attributes.each do |k, v|
+        puts "#{k} => #{v}"
+      end
     end
+
+    def initialize(attributes = {}, saved_on_sn = false, internal_call = false)
+      Incident.check_configuration
+      symbolized_attributes = Hash[attributes.map { |k, v| [k.to_sym, v] }]
+      if !symbolized_attributes[:number].nil? && !internal_call # allow setting INC number if it's called internally
+        raise "SN::ERROR: You are not allowed to set INC Number manually, the server will take care of that"
+      end
+      @attributes = symbolized_attributes
+      @saved_on_sn = saved_on_sn
+    end
+
+    def attributes
+      @attributes
+    end
+
+    def client # must be used only when displayvable is false
+      return User.find_by_sys_id(self.caller_id)
+    end
+
+    def method_missing(method, args = nil)
+      method_name = method.to_s
+      if match = method_name.match(/(.*)=/) # writer method
+        attribute = match[1]
+        if attribute == "number" && @saved_on_sn
+            raise "SN::ERROR: You are not allowed to set INC Number manually, the server will take care of that"
+        end
+        @attributes[attribute.to_sym] = args
+      else # reader method
+        @attributes[method_name.to_sym]
+      end
+    end
+
+    def save!
+      # if this is a new incident (still in memory and not on SN), and the user set the Incident number
+      # we raise an exception
+      if !@attributes[:number].nil? && !@saved_on_sn
+        raise "SN::ERROR: You are not allowed to set INC Number manually, the server will take care of that"
+      end
+      # we only create new incidents if it's not saved already
+      if !@saved_on_sn
+        response = Configuration.post_resource(table = "incident").post(self.attributes.to_json)
+      else
+        @saved_on_sn = false # Allow the number to be set again from the data pulled back
+        response = Configuration.update_resource(self.sys_id, table = "incident").patch(self.attributes.to_json)
+      end
+      hash = JSON.parse(response, {:symbolize_names => true})
+      # this is the object
+      # and there is always only one
+      # since we're creating or updating
+      inc_object = hash[:result]
+      inc_object.each do |key, value|
+        key_name = key.to_s
+        eval("self.#{key_name} = value")
+      end
+      @saved_on_sn = true
+      self
+    end
+
+    def self.find(inc_number)
+      Incident.check_configuration
+      inc_string = inc_number.to_s.match(/[123456789]+\d*$/).to_s
+      if inc_string.length > 7
+        raise "SN::Error: invalid Incident number"
+      end
+      query_hash = {}
+      query_hash[:number] = "INC" + "0"*(7-inc_string.length) + inc_string
+      response = Configuration.get_resource(query_hash, table = "incident").get();
+      # returned hash
+      hash = JSON.parse(response, {:symbolize_names => true})
+      # return the Incident object
+      inc_obj = Incident.new(attributes = hash[:result][0], saved_on_sn = true, internal_call = true)
+      if inc_obj.attributes.nil?
+        "SN::Alert: No incident with incident number #{query_hash[:number]} found"
+      else
+        inc_obj
+      end
+    end
+
+    def self.where(query_hash = {})
+      Incident.check_configuration
+      response = Configuration.get_resource(query_hash, table = "incident").get();
+      hash = JSON.parse(response, {:symbolize_names => true})
+      array_of_records = hash[:result]
+      array_of_inc = []
+      array_of_records.each do |record|
+        array_of_inc << Incident.new(attributes = record, saved_on_sn = true, internal_call = true)
+      end
+      array_of_inc
+    end
+
+    private
+    def self.check_configuration
+      if $root_url.nil? || $username.nil? || $password.nil?
+        raise "SN::Error: You have not configured yet, please run ServiceNow::Configuration.configure() first"
+      end
+    end
+  end
 end

--- a/lib/classes/user.rb
+++ b/lib/classes/user.rb
@@ -31,7 +31,7 @@ module ServiceNow
             query_hash[:sys_id] = sys_id
             response = Configuration.get_resource(query_hash = query_hash, table = "sys_user").get()
             hash = JSON.parse(response, { :symbolize_names => true })
-            user = User.new(hash[:records][0])
+            user = User.new(hash[:result][0])
             if user.attributes.nil?
                 puts "SN::Alert: No user with sys_id: #{sys_id} found"
                 return User.new

--- a/lib/classes/user.rb
+++ b/lib/classes/user.rb
@@ -16,7 +16,7 @@ module ServiceNow
             response = Configuration.get_resource(query_hash = query_hash, table = "sys_user").get()
             hash = JSON.parse(response, { :symbolize_names => true })
             # there should be only one
-            user = User.new(hash[:records][0])
+            user = User.new(hash[:result][0])
             if user.attributes.nil?
                 puts "SN::Alert: No user with netID: #{netid} found"
                 return User.new
@@ -46,7 +46,7 @@ module ServiceNow
             query_hash[:name] = name
             response = Configuration.get_resource(query_hash = query_hash, table = "sys_user").get()
             hash = JSON.parse(response, { :symbolize_names => true })
-            user = User.new(hash[:records][0])
+            user = User.new(hash[:result][0])
             if user.attributes.nil?
                 puts "SN::Alert: No user with user_name: #{name} found"
                 return User.new


### PR DESCRIPTION
API paths updated.
Response parsing changed (result vs records).
Allow an incident to be retrieved and then updated. (was not working when I called a .find followed by a .save!)
----
Following the current API described at: http://wiki.servicenow.com/index.php?title=REST_API#gsc.tab=0 